### PR TITLE
Add support for SQS dead-letter queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A [Dramatiq] broker that can be used with [Amazon SQS].
 This backend has a number of limitations compared to the built-in
 Redis and RMQ backends:
 
-* it does not currently implement a dead-letter queue,
 * the max amount of time messages can be delayed by is 15 minutes,
 * messages can be at most 256KiB large and
 * messages must be processed within 2 hours of being pulled, otherwise

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,7 +1,9 @@
 import dramatiq
 import pytest
 import time
+import json
 
+from botocore.stub import Stubber
 from dramatiq_sqs import SQSBroker
 
 
@@ -100,3 +102,37 @@ def test_can_requeue_consumed_messages(broker, queue_name):
     # Then I should be able to consume the message again immediately
     second_message = next(consumer)
     assert first_message == second_message
+
+
+def test_creates_dead_letter_queue():
+    # When I create a queue with the dead letter option and
+    # max receives specified
+    broker = SQSBroker(
+        namespace="dramatiq_sqs_tests",
+        dead_letter=True,
+        max_receives=20,
+    )
+    stubber = Stubber(broker.sqs.meta.client)
+
+    stubber.add_response("create_queue", {"QueueUrl": ""})
+    stubber.add_response("create_queue", {"QueueUrl": ""})
+    stubber.add_response("get_queue_attributes", {
+        "Attributes": {"QueueArn": "dlq"}
+    })
+    redrive_policy = {
+        "deadLetterTargetArn": "dlq",
+        "maxReceiveCount": "20"
+    }
+    expected_queue_params = {
+        "QueueUrl": "",
+        "Attributes": {
+            "RedrivePolicy": json.dumps(redrive_policy)
+        }
+    }
+    stubber.add_response("set_queue_attributes", {}, expected_queue_params)
+
+    # When I create a queue, a dead-letter queue should be created and a
+    # redrive policy matching the queue and max receives should be added
+    with stubber:
+        broker.declare_queue("test")
+        stubber.assert_no_pending_responses()


### PR DESCRIPTION
Initial pass at fixing #1. Defaults to not creating a dead-letter queue, but if `dead_letter` is true create one with the suffix `_dlq` and set the max receives in the redrive policy based on the `max_retries` parameter