### PR TITLE
doc: add example iam policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ broker = SQSBroker(
 )
 ```
 
+## Example IAM Policy
+
+For grained fine AWS permissions, the following IAM policy
+can be attached to the IAM User/Role where Dramatiq is running:
+
+``` json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sqs:CreateQueue",
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+                "sqs:DeleteMessageBatch",
+                "sqs:SendMessage",
+                "sqs:SendMessageBatch"
+            ],
+            "Resource": ["*"]
+        }
+    ]
+}
+```
+
+More info at [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
 
 ## License
 


### PR DESCRIPTION
Just adding an example IAM Policy in the `README.md`

I just migrated a Dramatiq instance from `RedisBroker` to `SQSBroker` today, and I had to add these SQS permissions to the IAM Role attached to the instance.