### PR TITLE
Allows tagging queues on creation

### DIFF
--- a/dramatiq_sqs/broker.py
+++ b/dramatiq_sqs/broker.py
@@ -68,6 +68,7 @@ class SQSBroker(dramatiq.Broker):
             retention: int = MAX_MESSAGE_RETENTION,
             dead_letter: bool = False,
             max_receives: int = MAX_RECEIVES,
+            tags: Optional[Dict[str, str]] = None,
             **options,
     ) -> None:
         super().__init__(middleware=middleware)
@@ -80,6 +81,7 @@ class SQSBroker(dramatiq.Broker):
         self.queues: Dict[str, Any] = {}
         self.dead_letter: bool = dead_letter
         self.max_receives: int = max_receives
+        self.tags: Optional[Dict[str, str]] = tags
         self.sqs: Any = boto3.resource("sqs", **options)
 
     def consume(self, queue_name: str, prefetch: int = 1, timeout: int = 30000) -> dramatiq.Consumer:
@@ -104,11 +106,22 @@ class SQSBroker(dramatiq.Broker):
                     "MessageRetentionPeriod": self.retention,
                 }
             )
+            if self.tags:
+                self.sqs.meta.client.tag_queue(
+                    QueueUrl=self.queues[queue_name].url,
+                    Tags=self.tags
+                )
+
             if self.dead_letter:
                 dead_letter_queue_name = f"{prefixed_queue_name}_dlq"
                 dead_letter_queue = self.sqs.create_queue(
                     QueueName=dead_letter_queue_name
                 )
+                if self.tags:
+                    self.sqs.meta.client.tag_queue(
+                        QueueUrl=dead_letter_queue.url,
+                        Tags=self.tags
+                    )
                 redrive_policy = {
                     "deadLetterTargetArn": dead_letter_queue.attributes["QueueArn"],
                     "maxReceiveCount": str(self.max_receives)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,9 @@ def broker():
             Pipelines(),
             Retries(min_backoff=1000, max_backoff=900000, max_retries=96),
         ],
+        tags={
+            "owner": "dramatiq_sqs_tests",
+        },
     )
     dramatiq.set_broker(broker)
     yield broker


### PR DESCRIPTION
Closes #12 

Adds tags to queues on creation. There are two ways to do this:

1. Specify the tags in the `create_queue` call.
2. Separately call `tag_queue` after creation.

The first option is clearly more efficient as there's only a single call. Unfortunately a not-entirely-documented 'feature' of SQS is that if you try to create an already-existing queue specifying tags and the tags are different to the existing tags (even if the existing queue has no tags) then the call will fail with an error saying the resource already exists with different tags, rather than re-tagging the queue.

The second approach is less efficient as it requires extra calls, but will add new tags and overwrite any existing tags that have changed (although won't remove any existing tags).

Given this choice I've elected to go with the second option partly because I think it means the behaviour of the library will be closer to the expectations of people using it, and partly because this is a new feature meaning anybody with existing queues won't have tags on them so this will allow them to add tags to those queues without having to recreate them.

For testing I've elected to add a tag to the broker that connects to AWS to exercise the new functionality against real resources, as well as add a test to verify that tags are added.