### PR TITLE
Add support for existing sqs queues

### DIFF
--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -139,7 +139,26 @@ def test_creates_dead_letter_queue():
 
     # And I've stubbed out all the relevant API calls
     stubber = Stubber(broker.sqs.meta.client)
+    error_response = {
+        'Error': {
+            'Code': 'AWS.SimpleQueueService.QueueDoesNotExist',
+            'Message': 'The specified queue does not exist.'
+        }
+    }
+    stubber.add_client_error(
+        "get_queue_url",
+        http_status_code=404,
+        service_error_code='QueueDoesNotExist',
+        service_message='The specified queue does not exist.',
+        response_meta=error_response)
     stubber.add_response("create_queue", {"QueueUrl": ""})
+    stubber.add_client_error(
+        "get_queue_url",
+        http_status_code=404,
+        service_error_code='QueueDoesNotExist',
+        service_message='The specified queue does not exist.',
+        response_meta=error_response)
+
     stubber.add_response("create_queue", {"QueueUrl": ""})
     stubber.add_response("get_queue_attributes", {"Attributes": {"QueueArn": "dlq"}})
     stubber.add_response("set_queue_attributes", {}, {
@@ -169,6 +188,18 @@ def test_tags_queues_on_create():
 
     # And I've stubbed out all the relevant API calls
     stubber = Stubber(broker.sqs.meta.client)
+    error_response = {
+        'Error': {
+            'Code': 'AWS.SimpleQueueService.QueueDoesNotExist',
+            'Message': 'The specified queue does not exist.'
+        }
+    }
+    stubber.add_client_error(
+        "get_queue_url",
+        http_status_code=404,
+        service_error_code='QueueDoesNotExist',
+        service_message='The specified queue does not exist.',
+        response_meta=error_response)
     stubber.add_response("create_queue", {"QueueUrl": ""})
     stubber.add_response("tag_queue", {}, {
         "QueueUrl": "",


### PR DESCRIPTION
# Motivation: Add support for existing sqs queues

The current broker implementation raises a `botocore.errorfactory.QueueNameExists` exception when the queue already exists. This PR tries to solve this replacing the call to `sqs.create_queue` with a call to a new internal method `_get_or_create_queue` that first tries to find the queue, and creates it when it doesn't exist. This avoids changing any logic in the `declare_queue` method.

The part I'm most unsure of is the extra efforts I need to put in the sqs stub for the tests, but they all are green now.

## TD;DR

I don't know if this could be of any help. I came accross the same situation as @dvazar in: https://github.com/retech-us/dramatiq_sqs/pull/1/ and https://github.com/Bogdanp/dramatiq_sqs/issues/14. Then I find out in https://github.com/Bogdanp/dramatiq_sqs/pull/19 that the PR was not accepted. I see in the comments references to too much work on various PRs to review, but I'm not able to find out if I can help with something.

Actually, currently I'm following @Bogdanp advice in https://github.com/Bogdanp/dramatiq_sqs/pull/19#issuecomment-1255391461 and subclassed SQSBroker and to override `declare_queues`. We've done exactly this in one of our systems and it is working perfectly.

It was then that I thought about the PR. So this are my 2¢.

Feel free to point me to any direction I can help with this and I'll try to do my best. Also, I'll understand if this is not helping. In that case, feel free to discard it.

In any case, thanks a lot for the great work with dramatiq!