### PR TITLE
feat: Add `SQSRetries` middleware for native `SQS` retry and `DLQ` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,69 @@ dramatiq.set_broker(broker)
 ```
 
 
+## Dead-Letter Queues and Retries
+
+Dramatiq's built-in `Retries` middleware re-enqueues a **new message** on
+each retry and deletes the original.  This means SQS's
+`ApproximateReceiveCount` never increments, so redrive policies never
+trigger and messages never reach a dead-letter queue.
+
+If you need DLQ support, use the `SQSRetries` middleware instead of the
+core `Retries` middleware.  `SQSRetries` keeps the **same SQS message**
+and uses visibility timeouts for backoff, allowing
+`ApproximateReceiveCount` to increment naturally and SQS redrive
+policies to work as expected.
+
+``` python
+import dramatiq
+
+from dramatiq.middleware import AgeLimit, TimeLimit, Callbacks, Pipelines
+from dramatiq_sqs import SQSBroker, SQSRetries
+
+broker = SQSBroker(
+    namespace="dramatiq_sqs_tests",
+    middleware=[
+        AgeLimit(),
+        TimeLimit(),
+        Callbacks(),
+        Pipelines(),
+        SQSRetries(min_backoff=1000, max_backoff=900000),
+    ],
+    dead_letter=True,
+    max_receives=5,
+)
+dramatiq.set_broker(broker)
+```
+
+When `dead_letter=True`, the retry limit is controlled entirely by SQS's
+`maxReceiveCount` (set via `max_receives`).  The middleware does not
+enforce its own `max_retries`. SQS's `maxReceiveCount` is the single
+source of truth for retry limits.
+
+When `dead_letter=False`, the middleware uses `ApproximateReceiveCount`
+to enforce `max_retries` and deletes the message once retries are
+exhausted.
+
+### on_retry_exhausted
+
+The `on_retry_exhausted` callback only fires when `dead_letter=False`. When
+`dead_letter=True`, SQS moves exhausted messages to the DLQ via the redrive
+policy and dramatiq is not involved, so the callback is never triggered.
+
+### Key differences from the core `Retries` middleware
+
+* Retried messages keep the same SQS message ID (not re-enqueued)
+* Backoff is implemented via visibility timeout (max 12 hours) instead of
+  message delay (max 15 minutes)
+* Message body is unchanged across retries (no traceback/retry metadata
+  appended)
+* `ApproximateReceiveCount` is used for retry tracking instead of
+  `message.options["retries"]`
+
+The IAM policy below includes `ChangeMessageVisibility` which is required
+by `SQSRetries`.
+
+
 ## Usage with [ElasticMQ]
 
 ``` python
@@ -67,7 +130,8 @@ Here are the IAM permissions needed by Dramatiq:
                 "sqs:DeleteMessage",
                 "sqs:DeleteMessageBatch",
                 "sqs:SendMessage",
-                "sqs:SendMessageBatch"
+                "sqs:SendMessageBatch",
+                "sqs:ChangeMessageVisibility"
             ],
             "Resource": ["*"]
         }

--- a/src/dramatiq_sqs/__init__.py
+++ b/src/dramatiq_sqs/__init__.py
@@ -1,10 +1,12 @@
 import importlib.metadata
 
 from .broker import SQSBroker
+from .middleware import SQSRetries
 
 __version__ = importlib.metadata.version("dramatiq_sqs")
 
 __all__ = [
     "SQSBroker",
+    "SQSRetries",
     "__version__",
 ]

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -268,8 +268,10 @@ class SQSConsumer(dramatiq.Consumer):
         message._sqs_message.delete()
         self.message_refc -= 1
 
-    #: Messages are added to DLQ by SQS redrive policy, so no actions are necessary
-    nack = ack
+    def nack(self, message: "_SQSMessage") -> None:
+        if getattr(message, "_sqs_nack_delete", True):
+            message._sqs_message.delete()
+        self.message_refc -= 1
 
     def requeue(self, messages: Iterable["_SQSMessage"]) -> None:
         for batch in chunk(messages, chunksize=10):

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -292,6 +292,7 @@ class SQSConsumer(dramatiq.Consumer):
         kw: dict[str, Any] = {
             "MaxNumberOfMessages": self.prefetch,
             "WaitTimeSeconds": self.wait_time_seconds,
+            "AttributeNames": ["ApproximateReceiveCount"],
         }
         if self.visibility_timeout is not None:
             kw["VisibilityTimeout"] = self.visibility_timeout

--- a/src/dramatiq_sqs/middleware.py
+++ b/src/dramatiq_sqs/middleware.py
@@ -1,0 +1,188 @@
+import traceback
+
+from dramatiq.common import compute_backoff
+from dramatiq.errors import Retry
+from dramatiq.logging import get_logger
+from dramatiq.middleware import Middleware
+
+from .broker import MAX_VISIBILITY_TIMEOUT_SECONDS
+
+#: The default minimum amount of backoff to apply to retried tasks (in milliseconds).
+DEFAULT_MIN_BACKOFF = 15000
+
+#: The default maximum amount of backoff to apply to retried tasks (in milliseconds).
+DEFAULT_MAX_BACKOFF = 86400000 * 7
+
+
+class SQSRetries(Middleware):
+    """Middleware that automatically retries failed tasks using SQS native
+    message redelivery instead of re-enqueueing new messages.
+
+    This middleware should be used **instead of** the core
+    :class:`Retries<dramatiq.middleware.Retries>` middleware when using
+    :class:`SQSBroker<dramatiq_sqs.SQSBroker>`.
+
+    Unlike the core ``Retries`` middleware which deletes the original message
+    and enqueues a new one, this middleware keeps the same SQS message and
+    uses visibility timeout to control backoff. This allows SQS's
+    ``ApproximateReceiveCount`` to increment correctly, enabling:
+
+    * **Dead-letter queue routing** via SQS redrive policies
+    * **Native retry tracking** via ``ApproximateReceiveCount``
+
+    When ``dead_letter=True`` on the broker, retry limits are controlled
+    entirely by the SQS redrive policy's ``maxReceiveCount``. The
+    ``max_retries`` parameter is not enforced by the middleware.
+
+    When ``dead_letter=False``, the middleware enforces ``max_retries``
+    using ``ApproximateReceiveCount`` and deletes messages that exceed the
+    limit.
+
+    Parameters:
+      max_retries: The maximum number of times a message can be received
+        before giving up. Only enforced when ``dead_letter=False``.
+      min_backoff: The minimum backoff in milliseconds. Defaults to 15 seconds.
+      max_backoff: The maximum backoff in milliseconds. Defaults to 7 days.
+      retry_when: An optional predicate ``(retries, exception) -> bool``
+        that determines whether a task should be retried.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_retries: int = 20,
+        min_backoff: int | None = None,
+        max_backoff: int | None = None,
+        retry_when=None,
+    ):
+        self.logger = get_logger(__name__, type(self))
+        self.max_retries = max_retries
+        self.min_backoff = min_backoff or DEFAULT_MIN_BACKOFF
+        self.max_backoff = max_backoff or DEFAULT_MAX_BACKOFF
+        self.retry_when = retry_when
+
+    @property
+    def actor_options(self):
+        return {
+            "max_retries",
+            "min_backoff",
+            "max_backoff",
+            "retry_when",
+            "throws",
+            "on_retry_exhausted",
+        }
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        if exception is None:
+            return
+
+        actor = broker.get_actor(message.actor_name)
+
+        throws = message.options.get("throws") or actor.options.get("throws")
+        if throws and isinstance(exception, throws):
+            self.logger.info("Aborting message %r.", message.message_id)
+            message.fail()
+            return
+
+        receive_count = int(
+            message._sqs_message.attributes.get("ApproximateReceiveCount", 1)
+        )
+
+        retry_when = actor.options.get("retry_when", self.retry_when)
+
+        if broker.dead_letter:
+            if retry_when is not None and not retry_when(receive_count - 1, exception):
+                self.logger.warning(
+                    "Retry predicate rejected message %r.", message.message_id
+                )
+                message._sqs_message.delete()
+                message.fail()
+                self._notify_retry_exhausted(broker, actor, message, receive_count - 1)
+                return
+
+            delay = self._compute_delay(actor, message, receive_count, exception)
+            self.logger.info(
+                "Retrying message %r (receive count: %d, visibility timeout: %ds).",
+                message.message_id,
+                receive_count,
+                delay,
+            )
+            message._sqs_message.change_visibility(VisibilityTimeout=delay)
+            message._sqs_nack_delete = False
+            message.fail()
+        else:
+            max_retries = message.options.get(
+                "max_retries",
+                actor.options.get("max_retries", self.max_retries),
+            )
+
+            if retry_when is not None and not retry_when(receive_count - 1, exception):
+                self.logger.warning(
+                    "Retry predicate rejected message %r.", message.message_id
+                )
+                message.fail()
+                self._notify_retry_exhausted(broker, actor, message, receive_count - 1)
+                return
+
+            if max_retries is not None and receive_count > max_retries:
+                self.logger.warning(
+                    "Retries exceeded for message %r (receive count: %d).",
+                    message.message_id,
+                    receive_count,
+                )
+                message.fail()
+                self._notify_retry_exhausted(broker, actor, message, receive_count - 1)
+                return
+
+            delay = self._compute_delay(actor, message, receive_count, exception)
+            self.logger.info(
+                "Retrying message %r (receive count: %d, visibility timeout: %ds).",
+                message.message_id,
+                receive_count,
+                delay,
+            )
+            message._sqs_message.change_visibility(VisibilityTimeout=delay)
+            message._sqs_nack_delete = False
+            message.fail()
+
+    def after_skip_message(self, broker, message):
+        message.fail()
+
+    def _compute_delay(self, actor, message, receive_count, exception):
+        if isinstance(exception, Retry) and exception.delay is not None:
+            delay_ms = exception.delay
+        else:
+            min_backoff = message.options.get(
+                "min_backoff",
+                actor.options.get("min_backoff", self.min_backoff),
+            )
+            max_backoff = message.options.get(
+                "max_backoff",
+                actor.options.get("max_backoff", self.max_backoff),
+            )
+            max_backoff = min(max_backoff, DEFAULT_MAX_BACKOFF)
+            _, delay_ms = compute_backoff(
+                receive_count - 1, factor=min_backoff, max_backoff=max_backoff
+            )
+
+        delay_seconds = min(delay_ms // 1000, MAX_VISIBILITY_TIMEOUT_SECONDS)
+        return max(delay_seconds, 0)
+
+    def _notify_retry_exhausted(self, broker, actor, message, retries):
+        target_actor_name = message.options.get(
+            "on_retry_exhausted"
+        ) or actor.options.get("on_retry_exhausted")
+        if target_actor_name:
+            max_retries = message.options.get(
+                "max_retries",
+                actor.options.get("max_retries", self.max_retries),
+            )
+            target_actor = broker.get_actor(target_actor_name)
+            target_actor.send(
+                message.asdict(),
+                {
+                    "retries": retries,
+                    "traceback": traceback.format_exc(limit=30),
+                    "max_retries": max_retries,
+                },
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from dramatiq.middleware import AgeLimit, Callbacks, Pipelines, Retries, TimeLim
 from mypy_boto3_sqs import SQSServiceResource
 from pytest_docker import Services
 
-from dramatiq_sqs import SQSBroker
+from dramatiq_sqs import SQSBroker, SQSRetries
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSServiceResource
@@ -76,6 +76,65 @@ def sqs(broker: SQSBroker) -> "SQSServiceResource":
 @pytest.fixture
 def queue_name(broker):
     return f"queue_{uuid.uuid4()}"
+
+
+@pytest.fixture
+def sqs_retries_broker(
+    elasticmq_endpoint_url: str, namespace: str, tags: dict[str, str]
+) -> Iterator[SQSBroker]:
+    broker = SQSBroker(
+        namespace=namespace,
+        middleware=[
+            AgeLimit(),
+            TimeLimit(),
+            Callbacks(),
+            Pipelines(),
+            SQSRetries(min_backoff=1000, max_backoff=900000, max_retries=3),
+        ],
+        dead_letter=True,
+        max_receives=3,
+        tags=tags,
+        visibility_timeout=5,
+        region_name="eu-central-1",
+        endpoint_url=elasticmq_endpoint_url,
+        aws_access_key_id="000000000000",
+        aws_secret_access_key="000000000000",
+    )
+    dramatiq.set_broker(broker)
+
+    yield broker
+
+    for queue in broker.queues.values():
+        queue.delete()
+
+
+@pytest.fixture
+def sqs_retries_broker_no_dlq(
+    elasticmq_endpoint_url: str, namespace: str, tags: dict[str, str]
+) -> Iterator[SQSBroker]:
+    broker = SQSBroker(
+        namespace=namespace,
+        middleware=[
+            AgeLimit(),
+            TimeLimit(),
+            Callbacks(),
+            Pipelines(),
+            SQSRetries(min_backoff=1000, max_backoff=900000, max_retries=3),
+        ],
+        dead_letter=False,
+        tags=tags,
+        visibility_timeout=5,
+        region_name="eu-central-1",
+        endpoint_url=elasticmq_endpoint_url,
+        aws_access_key_id="000000000000",
+        aws_secret_access_key="000000000000",
+    )
+    dramatiq.set_broker(broker)
+
+    yield broker
+
+    for queue in broker.queues.values():
+        queue.delete()
 
 
 @pytest.fixture

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,6 @@
+import time
+import uuid
+
 import dramatiq
 
 
@@ -39,3 +42,144 @@ class TestNackBehavior:
         second = next(consumer)
         assert second is not None
         assert second.message_id == message.message_id
+
+
+class TestSQSRetriesWithDLQ:
+    def test_retries_message_via_sqs_redelivery(self, sqs_retries_broker):
+        queue_name = f"queue_{uuid.uuid4()}"
+        attempts = []
+
+        @dramatiq.actor(queue_name=queue_name)
+        def failing_work():
+            attempts.append(1)
+            raise RuntimeError("fail")
+
+        failing_work.send()
+
+        worker = dramatiq.Worker(sqs_retries_broker)
+        worker.start()
+
+        try:
+            time.sleep(15)
+        finally:
+            worker.stop()
+
+        # Should have been retried multiple times (receive count incrementing)
+        assert len(attempts) > 1
+
+    def test_successful_message_is_acked(self, sqs_retries_broker):
+        queue_name = f"queue_{uuid.uuid4()}"
+        db = []
+
+        @dramatiq.actor(queue_name=queue_name)
+        def do_work(x):
+            db.append(x)
+
+        do_work.send(42)
+
+        worker = dramatiq.Worker(sqs_retries_broker)
+        worker.start()
+
+        try:
+            sqs_retries_broker.join(queue_name, timeout=30000)
+        finally:
+            worker.stop()
+
+        assert db == [42]
+
+    def test_throws_exception_is_not_retried(self, sqs_retries_broker):
+        queue_name = f"queue_{uuid.uuid4()}"
+        attempts = []
+
+        @dramatiq.actor(queue_name=queue_name, throws=(ValueError,))
+        def throwing_work():
+            attempts.append(1)
+            raise ValueError("expected")
+
+        throwing_work.send()
+
+        worker = dramatiq.Worker(sqs_retries_broker)
+        worker.start()
+
+        try:
+            time.sleep(10)
+        finally:
+            worker.stop()
+
+        # Should only have been attempted once (not retried)
+        assert len(attempts) == 1
+
+    def test_message_reaches_dlq(self, sqs_retries_broker):
+        queue_name = f"queue_{uuid.uuid4()}"
+
+        @dramatiq.actor(queue_name=queue_name)
+        def always_fails():
+            raise RuntimeError("permanent failure")
+
+        always_fails.send()
+
+        worker = dramatiq.Worker(sqs_retries_broker)
+        worker.start()
+
+        try:
+            # Wait long enough for max_receives (3) to be exhausted
+            time.sleep(20)
+        finally:
+            worker.stop()
+
+        # Check the DLQ has the message
+        namespace = sqs_retries_broker.namespace
+        dlq_name = f"{namespace}_{queue_name}_dlq"
+        dlq = sqs_retries_broker.sqs.get_queue_by_name(QueueName=dlq_name)
+        dlq.load()
+        dlq_count = int(dlq.attributes["ApproximateNumberOfMessages"])
+        assert dlq_count >= 1
+
+
+class TestSQSRetriesWithoutDLQ:
+    def test_retries_then_deletes_on_exhaustion(self, sqs_retries_broker_no_dlq):
+        queue_name = f"queue_{uuid.uuid4()}"
+        attempts = []
+
+        @dramatiq.actor(queue_name=queue_name, max_retries=2)
+        def failing_work():
+            attempts.append(1)
+            raise RuntimeError("fail")
+
+        failing_work.send()
+
+        worker = dramatiq.Worker(sqs_retries_broker_no_dlq)
+        worker.start()
+
+        try:
+            time.sleep(15)
+        finally:
+            worker.stop()
+
+        # Should have been attempted at least twice
+        assert len(attempts) >= 2
+
+        # Queue should be empty (message deleted after retries exhausted)
+        queue = sqs_retries_broker_no_dlq.queues[queue_name]
+        queue.load()
+        remaining = int(queue.attributes["ApproximateNumberOfMessages"])
+        assert remaining == 0
+
+    def test_approximate_receive_count_is_available(self, sqs_retries_broker_no_dlq):
+        queue_name = f"queue_{uuid.uuid4()}"
+
+        @dramatiq.actor(queue_name=queue_name)
+        def do_work():
+            pass
+
+        do_work.send()
+
+        consumer = sqs_retries_broker_no_dlq.consume(queue_name)
+        message = next(consumer)
+        assert message is not None
+
+        receive_count = message._sqs_message.attributes.get("ApproximateReceiveCount")
+        assert receive_count is not None
+        assert int(receive_count) >= 1
+
+        consumer.ack(message)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,41 @@
+import dramatiq
+
+
+class TestNackBehavior:
+    def test_nack_deletes_by_default(self, broker, queue_name):
+        @dramatiq.actor(queue_name=queue_name)
+        def do_work():
+            pass
+
+        do_work.send()
+
+        consumer = broker.consume(queue_name)
+        message = next(consumer)
+        assert message is not None
+
+        consumer.nack(message)
+
+        # Message should be deleted - next consume should return nothing
+        second = next(consumer)
+        assert second is None
+
+    def test_nack_does_not_delete_when_flag_is_false(self, broker, queue_name):
+        @dramatiq.actor(queue_name=queue_name)
+        def do_work():
+            pass
+
+        do_work.send()
+
+        consumer = broker.consume(queue_name, timeout=1000)
+        message = next(consumer)
+        assert message is not None
+
+        message._sqs_nack_delete = False
+        # Set visibility to 0 so the message is immediately available again
+        message._sqs_message.change_visibility(VisibilityTimeout=0)
+        consumer.nack(message)
+
+        # Message should still be in the queue
+        second = next(consumer)
+        assert second is not None
+        assert second.message_id == message.message_id


### PR DESCRIPTION
## Summary

The core `Retries` middleware re-enqueues a new message on each retry and deletes the original. This resets `ApproximateReceiveCount` on every attempt, so redrive policies never trigger and messages never reach the dead-letter queue.

`SQSRetries` is a drop-in replacement that keeps the same SQS message and uses visibility timeouts for backoff. This allows `ApproximateReceiveCount` to increment naturally and SQS redrive policies to work as expected.

Full context and discussion in #10.

## Changes

- **`SQSRetries` middleware** (`src/dramatiq_sqs/middleware.py`): replaces core `Retries` when using `SQSBroker`. Uses `ApproximateReceiveCount` for retry tracking and `ChangeMessageVisibility` for backoff.
- **Consumer `nack`**: respects a per-message `_sqs_nack_delete` flag so the middleware can prevent deletion when a message should be redelivered. Default behavior (delete) is unchanged for backward compatibility.
- **Consumer `receive_messages`**: now requests the `ApproximateReceiveCount` attribute from SQS.
- **README**: documents the new middleware, usage with DLQs, and key differences from core `Retries`.
- **Tests**: covers nack flag behavior, SQSRetries with and without DLQ, throws handling, and DLQ routing.

## Behavior

When `dead_letter=True`, the retry limit is controlled entirely by SQS's `maxReceiveCount`. The middleware only provides backoff via visibility timeout.

When `dead_letter=False`, the middleware enforces `max_retries` using `ApproximateReceiveCount` and deletes messages once retries are exhausted.

