### PR TITLE
chore: Embrace `itertools.batched`

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -2,13 +2,15 @@ import json
 import time
 from base64 import b64decode, b64encode
 from collections import deque
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import dramatiq
 from dramatiq.errors import QueueJoinTimeout
 from dramatiq.logging import get_logger
+
+from dramatiq_sqs import utils
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message, Queue, SQSServiceResource
@@ -272,7 +274,7 @@ class SQSConsumer(dramatiq.Consumer):
     nack = ack
 
     def requeue(self, messages: Iterable["_SQSMessage"]) -> None:
-        for batch in chunk(messages, chunksize=10):
+        for batch in utils.batched(messages, 10):
             # Setting the VisibilityTimeout to 0 makes the messages immediately visible again.
             response = self.queue.change_message_visibility_batch(
                 Entries=[
@@ -322,19 +324,3 @@ class _SQSMessage(dramatiq.MessageProxy):
         super().__init__(message)
 
         self._sqs_message = sqs_message
-
-
-T = TypeVar("T")
-
-
-def chunk(xs: Iterable[T], *, chunksize=10) -> Iterable[Sequence[T]]:
-    """Split a sequence into subseqs of chunksize length."""
-    chunk = []
-    for x in xs:
-        chunk.append(x)
-        if len(chunk) == chunksize:
-            yield chunk
-            chunk = []
-
-    if chunk:
-        yield chunk

--- a/src/dramatiq_sqs/utils.py
+++ b/src/dramatiq_sqs/utils.py
@@ -1,0 +1,15 @@
+import itertools
+import sys
+from collections.abc import Iterable
+from typing import TypeVar
+
+if sys.version_info >= (3, 12):
+    batched = itertools.batched
+else:
+    _T = TypeVar("_T")
+
+    def batched(iterable: Iterable[_T], n: int) -> Iterable[tuple[_T]]:
+        iterator = iter(iterable)
+
+        while batch := tuple(itertools.islice(iterator, n)):
+            yield batch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
-from dramatiq_sqs.broker import chunk
+from dramatiq_sqs import utils
 
 
-def test_chunk_can_split_iterators_into_chunks():
+def test_batched_splits_iterators_into_batches():
     # Given that I have a range from 0 to 12
     xs = range(13)
 
-    # When I pass that range to chunk with a chunksize of 2
-    chunks = chunk(xs, chunksize=2)
+    # When I pass that range to batched with n of 2
+    batches = utils.batched(xs, 2)
 
-    # Then I should get back these chunks
-    assert list(chunks) == [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12]]
+    # Then I should get back these batches
+    assert list(batches) == [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9), (10, 11), (12,)]


### PR DESCRIPTION
Use the stdlib function on 3.12+ or a simplified equivalent otherwise.