### PR TITLE
feat!: Lazily declared queues

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -81,6 +81,8 @@ class SQSBroker(dramatiq.Broker):
         tags: dict[str, str] | None = None,
         **options,
     ) -> None:
+        self.queue_names: set[str] = set()
+
         super().__init__(middleware=middleware)
 
         if (
@@ -112,12 +114,12 @@ class SQSBroker(dramatiq.Broker):
         prefetch: int = 1,
         timeout: int = MAX_WAIT_TIME_SECONDS * 1000,
     ) -> dramatiq.Consumer:
-        queue = self.queues.get(queue_name, None)
+        self._ensure_queue(queue_name)
 
-        if queue is None:
-            raise dramatiq.QueueNotFound(queue_name)
-
-        dead_letter_queue = self.dead_letter_queues.get(queue_name, None)
+        queue = self.queues[queue_name]
+        dead_letter_queue = (
+            self.dead_letter_queues[queue_name] if self.dead_letter else None
+        )
 
         return self.consumer_class(
             queue,
@@ -128,25 +130,32 @@ class SQSBroker(dramatiq.Broker):
         )
 
     def declare_queue(self, queue_name: str) -> None:
+        if queue_name not in self.queue_names:
+            self.emit_before("declare_queue", queue_name)
+            self.queue_names.add(queue_name)
+            self.emit_after("declare_queue", queue_name)
+
+    def _ensure_queue(self, queue_name: str) -> None:
+        if queue_name not in self.queue_names:
+            raise dramatiq.QueueNotFound(queue_name)
+
         sqs_queue_name = (
             f"{self.namespace}_{queue_name}" if self.namespace else queue_name
         )
-        sqs_dead_letter_queue_name = f"{sqs_queue_name}_dlq"
 
         if queue_name not in self.queues:
-            self.emit_before("declare_queue", queue_name)
             self.queues[queue_name] = self._get_or_create_sqs_queue(
                 sqs_queue_name, message_retention_period=self.retention, tags=self.tags
             )
 
-            if self.dead_letter:
-                self.dead_letter_queues[queue_name] = self._get_or_create_sqs_queue(
-                    sqs_dead_letter_queue_name,
-                    message_retention_period=self.dead_letter_retention,
-                    tags=self.tags,
-                )
+        sqs_dead_letter_queue_name = f"{sqs_queue_name}_dlq"
 
-            self.emit_after("declare_queue", queue_name)
+        if self.dead_letter and queue_name not in self.dead_letter_queues:
+            self.dead_letter_queues[queue_name] = self._get_or_create_sqs_queue(
+                sqs_dead_letter_queue_name,
+                message_retention_period=self.dead_letter_retention,
+                tags=self.tags,
+            )
 
     def _get_or_create_sqs_queue(
         self,
@@ -178,6 +187,8 @@ class SQSBroker(dramatiq.Broker):
         self, message: dramatiq.Message, *, delay: int | None = None
     ) -> dramatiq.Message:
         queue_name = message.queue_name
+        self._ensure_queue(queue_name)
+
         queue = self.queues[queue_name]
         delay_seconds = (delay or 0) // 1000
 
@@ -227,7 +238,7 @@ class SQSBroker(dramatiq.Broker):
             time.sleep(1)
 
     def get_declared_queues(self) -> Iterable[str]:
-        return set(self.queues)
+        return set(self.queue_names)
 
     def get_declared_delay_queues(self) -> Iterable[str]:
         return set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,9 @@ def broker(
     for queue in broker.queues.values():
         queue.delete()
 
+    for queue in broker.dead_letter_queues.values():
+        queue.delete()
+
 
 @pytest.fixture
 def sqs(broker: SQSBroker) -> "SQSServiceResource":

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,5 +1,6 @@
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import dramatiq
 import pytest
@@ -155,6 +156,21 @@ def test_can_requeue_consumed_messages(broker, queue_name):
     assert first_message == second_message
 
 
+@pytest.fixture(params=["consume", "enqueue"])
+def ensure_queue_trigger(
+    request: pytest.FixtureRequest, broker: SQSBroker
+) -> Callable[[str], Any]:
+    match request.param:
+        case "consume":
+            return lambda queue_name: broker.consume(queue_name)
+        case "enqueue":
+            return lambda queue_name: broker.enqueue(
+                dramatiq.Message(queue_name, "test", (), {}, {})
+            )
+
+    assert False, "invalid fixture param"
+
+
 @pytest.mark.parametrize(
     ("queue_name", "dead_letter", "sqs_queue_names"),
     [
@@ -169,12 +185,18 @@ def test_declare_queue(
     namespace: str,
     tags: dict[str, str],
     sqs: "SQSServiceResource",
+    ensure_queue_trigger: Callable[[str], Any],
 ) -> None:
     broker.declare_queue(queue_name)
 
-    sqs_queue_names = [n.format(namespace=namespace) for n in sqs_queue_names]
+    assert broker.get_declared_queues() == {queue_name}
+    assert len(list(sqs.queues.all())) == 0
+
+    ensure_queue_trigger(queue_name)
 
     for sqs_queue_name in sqs_queue_names:
-        queue = sqs.get_queue_by_name(QueueName=sqs_queue_name)
+        sqs_queue = sqs.get_queue_by_name(
+            QueueName=sqs_queue_name.format(namespace=namespace)
+        )
 
-        assert sqs.meta.client.list_queue_tags(QueueUrl=queue.url)["Tags"] == tags
+        assert sqs.meta.client.list_queue_tags(QueueUrl=sqs_queue.url)["Tags"] == tags


### PR DESCRIPTION
A workaround for the fact that the actor registration, middleware and broker init - and therefore queue declaration - are all somewhat tightly coupled ([more][1] [info][2]). The straightforward implementation of `declare_queue` may attempt to get/create SQS queues too soon (e.g. at import time), which may not be desirable (e.g. due to missing AWS credentials in local dev, tests etc.).

This change delays the first request to SQS until either `.consume` or `.enqueue` is called.

Dramatiq's own RabbitMQBroker employs [the same trick](https://github.com/Bogdanp/dramatiq/blob/0c1b8dd9c5a0d48c3ab187a2ec5c323312a214b3/dramatiq/brokers/rabbitmq.py#L294-L295).

[1]: https://github.com/Bogdanp/dramatiq/issues/324
[2]: https://github.com/Bogdanp/dramatiq/pull/762