### PR TITLE
fix: Use f-string in message size error so the limit is shown

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -200,7 +200,7 @@ class SQSBroker(dramatiq.Broker):
         encoded_message = b64encode(message.encode()).decode()
         if len(encoded_message) > MAX_MESSAGE_SIZE_BYTES:
             raise RuntimeError(
-                "Messages in SQS can be at most {MAX_MESSAGE_SIZE_BYTES} bytes large."
+                f"Messages in SQS can be at most {MAX_MESSAGE_SIZE_BYTES} bytes large."
             )
 
         self.logger.debug(


### PR DESCRIPTION
The error message for oversized messages was a plain string, so it printed the literal "{MAX_MESSAGE_SIZE_BYTES}" instead of the value.