### PR TITLE
feat: Add custom exceptions for enqueue validation

### DIFF
--- a/src/dramatiq_sqs/__init__.py
+++ b/src/dramatiq_sqs/__init__.py
@@ -1,10 +1,13 @@
 import importlib.metadata
 
 from .broker import SQSBroker
+from .exceptions import MessageDelayTooLong, MessageTooLarge
 
 __version__ = importlib.metadata.version("dramatiq_sqs")
 
 __all__ = [
+    "MessageDelayTooLong",
+    "MessageTooLarge",
     "SQSBroker",
     "__version__",
 ]

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -10,6 +10,7 @@ from dramatiq.errors import QueueJoinTimeout
 from dramatiq.logging import get_logger
 
 from dramatiq_sqs import utils
+from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message, Queue, SQSServiceResource
@@ -193,13 +194,13 @@ class SQSBroker(dramatiq.Broker):
         delay_seconds = (delay or 0) // 1000
 
         if delay_seconds > MAX_DELAY_SECONDS:
-            raise ValueError(
+            raise MessageDelayTooLong(
                 f"Messages in SQS cannot be delayed for longer than {MAX_DELAY_SECONDS} seconds."
             )
 
         encoded_message = b64encode(message.encode()).decode()
         if len(encoded_message) > MAX_MESSAGE_SIZE_BYTES:
-            raise RuntimeError(
+            raise MessageTooLarge(
                 "Messages in SQS can be at most {MAX_MESSAGE_SIZE_BYTES} bytes large."
             )
 

--- a/src/dramatiq_sqs/exceptions.py
+++ b/src/dramatiq_sqs/exceptions.py
@@ -1,0 +1,6 @@
+class MessageTooLarge(RuntimeError):
+    """Raised when a message exceeds the SQS maximum message size."""
+
+
+class MessageDelayTooLong(ValueError):
+    """Raised when a message delay exceeds the SQS maximum delay."""

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -6,6 +6,7 @@ import dramatiq
 import pytest
 
 from dramatiq_sqs import SQSBroker
+from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import SQSServiceResource
@@ -111,8 +112,8 @@ def test_cant_delay_messages_for_longer_than_15_seconds(broker, queue_name):
         pass
 
     # When I attempt to send that actor a message farther than 15 minutes into the future
-    # Then I should get back a ValueError
-    with pytest.raises(ValueError):
+    # Then I should get back a MessageDelayTooLong
+    with pytest.raises(MessageDelayTooLong):
         do_work.send_with_options(delay=3600000)
 
 
@@ -123,8 +124,8 @@ def test_cant_enqueue_messages_that_are_too_large(broker, queue_name):
         pass
 
     # When I attempt to send that actor a message that's too large after base64 encoding
-    # Then a RuntimeError should be raised
-    with pytest.raises(RuntimeError):
+    # Then a MessageTooLarge should be raised
+    with pytest.raises(MessageTooLarge):
         do_work.send("a" * 768 * 1024)
 
 


### PR DESCRIPTION
Introduce `MessageDelayTooLong` and `MessageTooLarge` exceptions so callers can handle these cases specifically instead of catching generic `ValueError` and `RuntimeError`.