### PR TITLE
fix: drain SQSConsumer prefetch buffer on close

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -310,6 +310,16 @@ class SQSConsumer(dramatiq.Consumer):
             requeued_messages = response.get("Successful", [])
             self.message_refc -= len(requeued_messages)
 
+    def close(self) -> None:
+        # Drain the prefetch buffer: messages fetched from SQS but never
+        # returned via ``__next__`` are invisible until ``VisibilityTimeout``
+        # expires. ``Worker.stop`` drains ``work_queue`` and ``delay_queue``
+        # but has no awareness of this internal buffer, so ``close`` is the
+        # last hook to put them back.
+        buffered, self.messages = list(self.messages), deque()
+        if buffered:
+            self.requeue(buffered)
+
     def __next__(self) -> dramatiq.Message | None:
         kw: dict[str, Any] = {
             "MaxNumberOfMessages": self.prefetch,

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -157,6 +157,38 @@ def test_can_requeue_consumed_messages(broker, queue_name):
     assert first_message == second_message
 
 
+def test_close_requeues_prefetched_messages(broker, queue_name):
+    # Given that I have an actor and a handful of pending messages
+    @dramatiq.actor(queue_name=queue_name)
+    def do_work():
+        pass
+
+    for _ in range(3):
+        do_work.send()
+
+    # When I start consuming with a prefetch large enough to pull them all
+    # into the internal buffer at once
+    consumer = broker.consume(queue_name, prefetch=5)
+    first = next(consumer)
+    assert first is not None
+
+    # Then there should be buffered messages that haven't been returned yet
+    buffered_count = len(consumer.messages)
+    assert buffered_count >= 1
+
+    # When I close the consumer
+    consumer.close()
+
+    # Then the internal buffer is drained
+    assert len(consumer.messages) == 0
+
+    # And a fresh consumer can read the buffered messages immediately —
+    # meaning they were requeued, not left invisible until VisibilityTimeout.
+    new_consumer = broker.consume(queue_name, prefetch=5)
+    for _ in range(buffered_count):
+        assert next(new_consumer) is not None
+
+
 @pytest.fixture(params=["consume", "enqueue"])
 def ensure_queue_trigger(
     request: pytest.FixtureRequest, broker: SQSBroker


### PR DESCRIPTION
Otherwise there are cases where the prefetch buffer still contains messags These should be returned to the queue.

We overrride the cosuners close to push back all messages to the queue (well set visibility to 0)

Added some tests as well that kind of artifically simulate the behavior.