### PR TITLE
fix: back off in `__next__` when prefetch limit reached

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import boto3
 import dramatiq
+from dramatiq.common import compute_backoff
 from dramatiq.errors import QueueJoinTimeout
 from dramatiq.logging import get_logger
 
@@ -281,6 +282,7 @@ class SQSConsumer(dramatiq.Consumer):
 
         self.messages: deque = deque()
         self.message_refc = 0
+        self.misses = 0
 
     def ack(self, message: "_SQSMessage") -> None:
         message._sqs_message.delete()
@@ -319,7 +321,9 @@ class SQSConsumer(dramatiq.Consumer):
             kw["VisibilityTimeout"] = self.visibility_timeout
 
         try:
-            return self.messages.popleft()
+            message = self.messages.popleft()
+            self.misses = 0
+            return message
         except IndexError:
             if self.message_refc < self.prefetch:
                 for sqs_message in self.queue.receive_messages(**kw):
@@ -334,8 +338,19 @@ class SQSConsumer(dramatiq.Consumer):
                         )
 
             try:
-                return self.messages.popleft()
+                message = self.messages.popleft()
+                self.misses = 0
+                return message
             except IndexError:
+                # Back off to avoid spinning when the prefetch limit is
+                # reached or no messages are available. SQS long-polling
+                # already throttles fetches, but when message_refc >=
+                # prefetch we don't fetch at all and would otherwise busy
+                # loop until a worker thread frees a slot.
+                self.misses, backoff_ms = compute_backoff(
+                    self.misses, max_backoff=self.wait_time_seconds * 1000 or 1000
+                )
+                time.sleep(backoff_ms / 1000)
                 return None
 
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -157,7 +157,6 @@ def test_can_requeue_consumed_messages(broker, queue_name):
     assert first_message == second_message
 
 
-@pytest.mark.xfail(strict=True, reason="issue #55: __next__ spins when prefetch reached")
 def test_consumer_backs_off_when_prefetch_limit_reached(broker, queue_name):
     # Given an actor and a consumer with prefetch=1
     @dramatiq.actor(queue_name=queue_name)

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -157,6 +157,35 @@ def test_can_requeue_consumed_messages(broker, queue_name):
     assert first_message == second_message
 
 
+@pytest.mark.xfail(strict=True, reason="issue #55: __next__ spins when prefetch reached")
+def test_consumer_backs_off_when_prefetch_limit_reached(broker, queue_name):
+    # Given an actor and a consumer with prefetch=1
+    @dramatiq.actor(queue_name=queue_name)
+    def do_work():
+        pass
+
+    # When I send a message and consume it (without acking)
+    do_work.send()
+    consumer = broker.consume(queue_name, prefetch=1, timeout=1000)
+    in_flight = next(consumer)
+    assert in_flight is not None
+    assert consumer.message_refc == 1
+
+    # And then call __next__ repeatedly while the prefetch limit is reached.
+    deadline = time.monotonic() + 1.0
+    calls = 0
+    while time.monotonic() < deadline:
+        result = next(consumer)
+        assert result is None
+        calls += 1
+
+    # Then the consumer must have backed off so the number of __next__
+    # calls in 1 second stays small instead of spinning.
+    assert calls < 50
+
+    consumer.ack(in_flight)
+
+
 @pytest.fixture(params=["consume", "enqueue"])
 def ensure_queue_trigger(
     request: pytest.FixtureRequest, broker: SQSBroker


### PR DESCRIPTION
Fixes #55.

When `message_refc >= prefetch`, `_SQSConsumer.__next__` returned `None` immediately without sleeping, causing `_ConsumerThread` to spin at maximum CPU until a worker freed a slot. Profiling in the linked issue showed `__next__` being called over 600k times in 10s with `dramatiq_queue_prefetch=1`.

This tracks consecutive empty calls and applies jittered exponential backoff via `compute_backoff` before returning `None`, mirroring the pattern in dramatiq's Redis broker. The miss counter resets whenever a real message is returned.