### PR TITLE
fix: use the thread-safe SQS client API instead of boto3 resources

### DIFF
--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -14,7 +14,8 @@ from dramatiq_sqs import utils
 from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
-    from mypy_boto3_sqs.service_resource import Message, Queue, SQSServiceResource
+    from mypy_boto3_sqs import SQSClient
+    from mypy_boto3_sqs.type_defs import MessageTypeDef
 
 # SQS quotas:
 # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
@@ -107,13 +108,20 @@ class SQSBroker(dramatiq.Broker):
         self.namespace: str | None = namespace
         self.retention = retention
         self.max_message_size = max_message_size
-        self.queues: dict[str, Queue] = {}
+        #: Maps Dramatiq queue names to their SQS queue URLs.
+        self.queues: dict[str, str] = {}
         self.dead_letter = dead_letter
-        self.dead_letter_queues: dict[str, Queue] = {}
+        #: Maps Dramatiq queue names to their SQS dead-letter queue URLs.
+        self.dead_letter_queues: dict[str, str] = {}
         self.dead_letter_retention = dead_letter_retention
         self.visibility_timeout = visibility_timeout
         self.tags = tags
-        self.sqs: SQSServiceResource = boto3.resource("sqs", **options)
+        # A broker is shared by every worker thread (and, for ``enqueue``, by
+        # arbitrary application threads such as a web server's).  boto3 resources
+        # are not thread-safe and must not be shared across threads, but clients
+        # are, so all SQS calls go through a single shared client.
+        # https://docs.aws.amazon.com/boto3/latest/guide/clients.html#multithreading-or-multiprocessing-with-clients
+        self.client: SQSClient = boto3.client("sqs", **options)
 
     @property
     def consumer_class(self):
@@ -127,16 +135,16 @@ class SQSBroker(dramatiq.Broker):
     ) -> dramatiq.Consumer:
         self._ensure_queue(queue_name)
 
-        queue = self.queues[queue_name]
-        dead_letter_queue = (
+        dead_letter_queue_url = (
             self.dead_letter_queues[queue_name] if self.dead_letter else None
         )
 
         return self.consumer_class(
-            queue,
+            self.client,
+            self.queues[queue_name],
             prefetch,
             timeout,
-            dead_letter_queue=dead_letter_queue,
+            dead_letter_queue_url=dead_letter_queue_url,
             visibility_timeout=self.visibility_timeout,
         )
 
@@ -174,25 +182,25 @@ class SQSBroker(dramatiq.Broker):
         *,
         message_retention_period: int,
         tags: dict[str, str] | None = None,
-    ) -> "Queue":
+    ) -> str:
         try:
-            queue = self.sqs.get_queue_by_name(QueueName=sqs_queue_name)
+            queue_url = self.client.get_queue_url(QueueName=sqs_queue_name)["QueueUrl"]
 
             if tags:
-                self.sqs.meta.client.tag_queue(QueueUrl=queue.url, Tags=tags)
+                self.client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
-        except self.sqs.meta.client.exceptions.QueueDoesNotExist:
+        except self.client.exceptions.QueueDoesNotExist:
             self.logger.debug(f"Queue {sqs_queue_name} does not exist, creating")
 
-            queue = self.sqs.create_queue(
+            queue_url = self.client.create_queue(
                 QueueName=sqs_queue_name,
                 Attributes={
                     "MessageRetentionPeriod": str(message_retention_period),
                 },
                 tags=tags or {},
-            )
+            )["QueueUrl"]
 
-        return queue
+        return queue_url
 
     def enqueue(
         self, message: dramatiq.Message, *, delay: int | None = None
@@ -200,7 +208,7 @@ class SQSBroker(dramatiq.Broker):
         queue_name = message.queue_name
         self._ensure_queue(queue_name)
 
-        queue = self.queues[queue_name]
+        queue_url = self.queues[queue_name]
         delay_seconds = (delay or 0) // 1000
 
         if delay_seconds > MAX_DELAY_SECONDS:
@@ -218,7 +226,8 @@ class SQSBroker(dramatiq.Broker):
             "Enqueueing message %r on queue %r.", message.message_id, queue_name
         )
         self.emit_before("enqueue", message, delay)
-        queue.send_message(
+        self.client.send_message(
+            QueueUrl=queue_url,
             MessageBody=encoded_message,
             DelaySeconds=delay_seconds,
         )
@@ -226,7 +235,7 @@ class SQSBroker(dramatiq.Broker):
         return message
 
     def join(self, queue_name: str, *, timeout: int | None = None) -> None:
-        queue = self.queues[queue_name]
+        queue_url = self.queues[queue_name]
 
         deadline = timeout and time.monotonic() + timeout
 
@@ -234,12 +243,19 @@ class SQSBroker(dramatiq.Broker):
             if deadline and time.monotonic() >= deadline:
                 raise QueueJoinTimeout(queue_name)
 
-            queue.load()
+            attributes = self.client.get_queue_attributes(
+                QueueUrl=queue_url,
+                AttributeNames=[
+                    "ApproximateNumberOfMessages",
+                    "ApproximateNumberOfMessagesDelayed",
+                    "ApproximateNumberOfMessagesNotVisible",
+                ],
+            )["Attributes"]
             message_count = sum(
                 (
-                    int(queue.attributes["ApproximateNumberOfMessages"]),
-                    int(queue.attributes["ApproximateNumberOfMessagesDelayed"]),
-                    int(queue.attributes["ApproximateNumberOfMessagesNotVisible"]),
+                    int(attributes["ApproximateNumberOfMessages"]),
+                    int(attributes["ApproximateNumberOfMessagesDelayed"]),
+                    int(attributes["ApproximateNumberOfMessagesNotVisible"]),
                 )
             )
 
@@ -258,16 +274,18 @@ class SQSBroker(dramatiq.Broker):
 class SQSConsumer(dramatiq.Consumer):
     def __init__(
         self,
-        queue: "Queue",
+        client: "SQSClient",
+        queue_url: str,
         prefetch: int,
         timeout: int,
         *,
-        dead_letter_queue: "Queue",
+        dead_letter_queue_url: str | None,
         visibility_timeout: int | None = None,
     ) -> None:
         self.logger = get_logger(__name__, type(self))
-        self.queue = queue
-        self.dead_letter_queue = dead_letter_queue
+        self.client = client
+        self.queue_url = queue_url
+        self.dead_letter_queue_url = dead_letter_queue_url
         self.prefetch = min(prefetch, MAX_PREFETCH)
 
         self.visibility_timeout = visibility_timeout
@@ -294,28 +312,38 @@ class SQSConsumer(dramatiq.Consumer):
         self.misses = 0
 
     def ack(self, message: "_SQSMessage") -> None:
-        message._sqs_message.delete()
+        self.client.delete_message(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=message._sqs_message["ReceiptHandle"],
+        )
         self.message_refc -= 1
 
     def nack(self, message: "_SQSMessage") -> None:
-        if self.dead_letter_queue is not None:
-            self.dead_letter_queue.send_message(MessageBody=message._sqs_message.body)
+        if self.dead_letter_queue_url is not None:
+            self.client.send_message(
+                QueueUrl=self.dead_letter_queue_url,
+                MessageBody=message._sqs_message["Body"],
+            )
 
-        message._sqs_message.delete()
+        self.client.delete_message(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=message._sqs_message["ReceiptHandle"],
+        )
         self.message_refc -= 1
 
     def requeue(self, messages: Iterable["_SQSMessage"]) -> None:
         for batch in utils.batched(messages, 10):
             # Setting the VisibilityTimeout to 0 makes the messages immediately visible again.
-            response = self.queue.change_message_visibility_batch(
+            response = self.client.change_message_visibility_batch(
+                QueueUrl=self.queue_url,
                 Entries=[
                     {
                         "Id": str(i),
-                        "ReceiptHandle": message._sqs_message.receipt_handle,
+                        "ReceiptHandle": message._sqs_message["ReceiptHandle"],
                         "VisibilityTimeout": 0,
                     }
                     for i, message in enumerate(batch)
-                ]
+                ],
             )
 
             requeued_messages = response.get("Successful", [])
@@ -345,15 +373,16 @@ class SQSConsumer(dramatiq.Consumer):
             return message
         except IndexError:
             if self.message_refc < self.prefetch:
-                for sqs_message in self.queue.receive_messages(**kw):
+                response = self.client.receive_message(QueueUrl=self.queue_url, **kw)
+                for sqs_message in response.get("Messages", []):
                     try:
-                        encoded_message = b64decode(sqs_message.body)
+                        encoded_message = b64decode(sqs_message["Body"])
                         dramatiq_message = dramatiq.Message.decode(encoded_message)
                         self.messages.append(_SQSMessage(sqs_message, dramatiq_message))
                         self.message_refc += 1
                     except Exception:  # pragma: no cover
                         self.logger.exception(
-                            "Failed to decode message: %r", sqs_message.body
+                            "Failed to decode message: %r", sqs_message["Body"]
                         )
 
             try:
@@ -374,7 +403,9 @@ class SQSConsumer(dramatiq.Consumer):
 
 
 class _SQSMessage(dramatiq.MessageProxy):
-    def __init__(self, sqs_message: "Message", message: dramatiq.Message) -> None:
+    def __init__(
+        self, sqs_message: "MessageTypeDef", message: dramatiq.Message
+    ) -> None:
         super().__init__(message)
 
         self._sqs_message = sqs_message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING
 import dramatiq
 import pytest
 from dramatiq.middleware import AgeLimit, Callbacks, Pipelines, Retries, TimeLimit
-from mypy_boto3_sqs import SQSServiceResource
+from mypy_boto3_sqs import SQSClient
 from pytest_docker import Services
 
 from dramatiq_sqs import SQSBroker
 
 if TYPE_CHECKING:
-    from mypy_boto3_sqs import SQSServiceResource
+    from mypy_boto3_sqs import SQSClient
 
 
 @pytest.fixture(scope="session")
@@ -64,16 +64,16 @@ def broker(
 
     yield broker
 
-    for queue in broker.queues.values():
-        queue.delete()
+    for queue_url in broker.queues.values():
+        broker.client.delete_queue(QueueUrl=queue_url)
 
-    for queue in broker.dead_letter_queues.values():
-        queue.delete()
+    for queue_url in broker.dead_letter_queues.values():
+        broker.client.delete_queue(QueueUrl=queue_url)
 
 
 @pytest.fixture
-def sqs(broker: SQSBroker) -> "SQSServiceResource":
-    return broker.sqs
+def sqs(broker: SQSBroker) -> "SQSClient":
+    return broker.client
 
 
 @pytest.fixture

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -9,7 +9,7 @@ from dramatiq_sqs import SQSBroker
 from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
-    from mypy_boto3_sqs.service_resource import SQSServiceResource
+    from mypy_boto3_sqs import SQSClient
 
 
 def test_can_enqueue_and_process_messages(broker, worker, queue_name):
@@ -54,8 +54,10 @@ def test_failed_messages_are_sent_to_dlq(
 
     broker.join(queue_name)
 
-    dlq = broker.dead_letter_queues[queue_name]
-    messages = dlq.receive_messages(MaxNumberOfMessages=10)
+    dlq_url = broker.dead_letter_queues[queue_name]
+    messages = broker.client.receive_message(
+        QueueUrl=dlq_url, MaxNumberOfMessages=10
+    ).get("Messages", [])
     assert len(messages) == attempts
 
 
@@ -266,19 +268,19 @@ def test_declare_queue(
     broker: SQSBroker,
     namespace: str,
     tags: dict[str, str],
-    sqs: "SQSServiceResource",
+    sqs: "SQSClient",
     ensure_queue_trigger: Callable[[str], Any],
 ) -> None:
     broker.declare_queue(queue_name)
 
     assert broker.get_declared_queues() == {queue_name}
-    assert len(list(sqs.queues.all())) == 0
+    assert len(sqs.list_queues().get("QueueUrls", [])) == 0
 
     ensure_queue_trigger(queue_name)
 
     for sqs_queue_name in sqs_queue_names:
-        sqs_queue = sqs.get_queue_by_name(
+        queue_url = sqs.get_queue_url(
             QueueName=sqs_queue_name.format(namespace=namespace)
-        )
+        )["QueueUrl"]
 
-        assert sqs.meta.client.list_queue_tags(QueueUrl=sqs_queue.url)["Tags"] == tags
+        assert sqs.list_queue_tags(QueueUrl=queue_url)["Tags"] == tags


### PR DESCRIPTION
Closes #23.

boto3 resources aren't thread-safe and shouldn't be shared between threads, but the broker shared its `Queue` resources across every worker thread and across any app thread calling `enqueue` (e.g. a gunicorn web process). This routes all SQS calls through a single boto3 client instead, which is [documented as thread-safe](https://docs.aws.amazon.com/boto3/latest/guide/clients.html#multithreading-or-multiprocessing-with-clients).

## Changes
- All SQS calls go through a single shared `boto3.client("sqs")` (`broker.client`): `send_message`, `receive_message`, `delete_message`, `change_message_visibility_batch`, `get_queue_attributes`, `get_queue_url` / `create_queue` / `tag_queue`.
- `broker.queues` / `broker.dead_letter_queues` now hold queue URL strings instead of `Queue` resources.
- `SQSConsumer` takes `(client, queue_url, ..., dead_letter_queue_url=...)`; `_SQSMessage` wraps the `receive_message` dict.
- Tests and conftest updated to the client API.

## Breaking changes
For the v1.0.0 milestone (_the README already warns of pre-1.0 breakage_):
- `broker.sqs` is removed, use `broker.client`.
- `broker.queues` / `broker.dead_letter_queues` values are now URL strings, not `Queue` resources.
- `SQSConsumer.__init__` signature and attribute names changed.

## Verification
- `ruff check`, `ruff format --check`, `ty check` all pass.
- `pytest`: 16 passed against ElasticMQ.