### PR TITLE
feat: configure max message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This backend has a number of limitations compared to the built-in
 Redis and RMQ backends:
 
 * the max amount of time messages can be delayed by is 15 minutes,
-* messages can be at most 1MiB large and
+* messages can be at most 1MiB large by default (configurable via `max_message_size`) and
 * messages must be processed within 12 hours of being pulled,
 otherwise they will be redelivered.
 

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -63,6 +63,10 @@ class SQSBroker(dramatiq.Broker):
       dead_letter: Whether to add a dead-letter queue. Defaults to false.
       dead_letter_retention: The number of seconds messages will be retained for in the
         dead letter queue (if enabled). Defaults to 14 days.
+      max_message_size: The maximum size (in bytes) of a base64-encoded message.
+        Messages larger than this raise :class:`MessageTooLarge` on enqueue.
+        Defaults to 1MiB (the SQS maximum), but may be raised for SQS-compatible
+        backends that support larger messages.
       **options: Additional options that are passed to boto3.
 
     .. _Dramatiq: https://dramatiq.io
@@ -80,6 +84,7 @@ class SQSBroker(dramatiq.Broker):
         dead_letter: bool = False,
         dead_letter_retention: int = MAX_MESSAGE_RETENTION_SECONDS,
         visibility_timeout: int | None = MAX_VISIBILITY_TIMEOUT_SECONDS,
+        max_message_size: int = MAX_MESSAGE_SIZE_BYTES,
         tags: dict[str, str] | None = None,
         **options,
     ) -> None:
@@ -96,8 +101,12 @@ class SQSBroker(dramatiq.Broker):
                 f"{MAX_MESSAGE_RETENTION_SECONDS} seconds."
             )
 
+        if max_message_size < 1:
+            raise ValueError("'max_message_size' must be a positive number of bytes.")
+
         self.namespace: str | None = namespace
         self.retention = retention
+        self.max_message_size = max_message_size
         self.queues: dict[str, Queue] = {}
         self.dead_letter = dead_letter
         self.dead_letter_queues: dict[str, Queue] = {}
@@ -200,9 +209,9 @@ class SQSBroker(dramatiq.Broker):
             )
 
         encoded_message = b64encode(message.encode()).decode()
-        if len(encoded_message) > MAX_MESSAGE_SIZE_BYTES:
+        if len(encoded_message) > self.max_message_size:
             raise MessageTooLarge(
-                f"Messages in SQS can be at most {MAX_MESSAGE_SIZE_BYTES} bytes large."
+                f"Messages in SQS can be at most {self.max_message_size} bytes large."
             )
 
         self.logger.debug(

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -129,6 +129,27 @@ def test_cant_enqueue_messages_that_are_too_large(broker, queue_name):
         do_work.send("a" * 768 * 1024)
 
 
+def test_max_message_size_is_configurable(broker, queue_name):
+    # Given that I lower the broker's max message size
+    broker.max_message_size = 1024
+
+    @dramatiq.actor(queue_name=queue_name)
+    def do_work(s):
+        pass
+
+    # When I attempt to send a message that exceeds the configured limit
+    # Then a MessageTooLarge should be raised
+    with pytest.raises(MessageTooLarge):
+        do_work.send("a" * 2048)
+
+
+def test_max_message_size_is_validated():
+    # When I attempt to instantiate a broker with a non-positive max message size
+    # Then a ValueError should be raised
+    with pytest.raises(ValueError):
+        SQSBroker(max_message_size=0)
+
+
 def test_retention_period_is_validated():
     # When I attempt to instantiate a broker with an invalid retention period
     # Then a ValueError should be raised


### PR DESCRIPTION
Implementation different from AWS sometimes have different max message sizes On top of that it gives extra control for the sizes send to SQS.