### PR TITLE
feat: add opt-in visibility-timeout heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,46 @@ broker = SQSBroker(
 )
 ```
 
+## Heartbeat (visibility timeout extension)
+
+The heartbeat is **off by default**. When enabled, the consumer periodically
+extends the SQS visibility timeout of in-flight messages via
+`ChangeMessageVisibility`, which protects against two issues:
+
+1. A long-running task whose runtime exceeds the queue's `VisibilityTimeout`
+   would otherwise be redelivered to another worker while still being
+   processed (duplicate execution).
+2. With `prefetch > 1`, prefetched messages sit in the consumer's local buffer.
+   Without heartbeats they can expire while waiting for a worker to pick them
+   up, even if the queue's `VisibilityTimeout` looks generous compared to
+   per-task processing time.
+
+Because messages are tracked from the moment they are received (not from when
+processing starts), both cases are covered. If a worker dies, heartbeats stop
+and SQS makes the message visible again within `heartbeat_extension` seconds,
+so you can set a short visibility window and still avoid mid-flight redelivery.
+
+Enable it by setting `heartbeat_interval`:
+
+``` python
+broker = SQSBroker(
+    # ...
+    heartbeat_interval=30,        # extend visibility every 30s (None disables)
+    heartbeat_extension=120,      # each beat pushes the deadline 120s forward
+    heartbeat_max_extensions=60,  # runaway cap: drop after this many beats
+)
+```
+
+`heartbeat_extension` must be greater than `heartbeat_interval` so a message
+can't expire between beats. After `heartbeat_max_extensions` beats a message is
+dropped from tracking and left to SQS to redeliver, so a stuck worker can't pin
+it forever.
+
+Beats run on one background thread per consumer. Because of the GIL, a worker
+running CPU-bound work that never releases it can delay beats, so keep a wide
+margin between `heartbeat_interval` and `heartbeat_extension` (the defaults
+leave 90s of slack).
+
 ## Example IAM Policy
 
 Here are the IAM permissions needed by Dramatiq:
@@ -70,13 +110,17 @@ Here are the IAM permissions needed by Dramatiq:
                 "sqs:DeleteMessage",
                 "sqs:DeleteMessageBatch",
                 "sqs:SendMessage",
-                "sqs:SendMessageBatch"
+                "sqs:SendMessageBatch",
+                "sqs:ChangeMessageVisibility"
             ],
             "Resource": ["*"]
         }
     ]
 }
 ```
+
+`sqs:ChangeMessageVisibility` covers both the batch requeue (used on worker
+shutdown) and the heartbeat.
 
 ## License
 

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -10,7 +10,7 @@ from dramatiq.common import compute_backoff
 from dramatiq.errors import QueueJoinTimeout
 from dramatiq.logging import get_logger
 
-from dramatiq_sqs import utils
+from dramatiq_sqs import heartbeat, utils
 from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
@@ -67,6 +67,21 @@ class SQSBroker(dramatiq.Broker):
         Messages larger than this raise :class:`MessageTooLarge` on enqueue.
         Defaults to 1MiB (the SQS maximum), but may be raised for SQS-compatible
         backends that support larger messages.
+      heartbeat_interval: How often (in seconds) to extend the visibility
+        timeout of in-flight messages via ``ChangeMessageVisibility``. When set,
+        the consumer keeps received messages invisible for as long as this
+        worker is alive, so a task that outlives the queue's ``visibility_timeout``
+        (or a message sitting in the prefetch buffer) is not redelivered
+        mid-flight. If the worker dies, beats stop and SQS releases the message
+        within ``heartbeat_extension`` seconds. Defaults to ``None`` (disabled).
+        Enabling it requires the ``sqs:ChangeMessageVisibility`` IAM permission.
+      heartbeat_extension: How many seconds each beat pushes the visibility
+        deadline forward. Must be greater than ``heartbeat_interval`` so a
+        message can't expire between beats. Defaults to 120 seconds.
+      heartbeat_max_extensions: Cap on the number of beats per message, a guard
+        against a stuck worker pinning a message forever. After this many beats
+        the message is dropped from tracking and SQS redelivers it. Defaults to
+        60, which with a 30s interval keeps a message alive for up to ~30 minutes.
       **options: Additional options that are passed to boto3.
 
     .. _Dramatiq: https://dramatiq.io
@@ -85,6 +100,9 @@ class SQSBroker(dramatiq.Broker):
         dead_letter_retention: int = MAX_MESSAGE_RETENTION_SECONDS,
         visibility_timeout: int | None = MAX_VISIBILITY_TIMEOUT_SECONDS,
         max_message_size: int = MAX_MESSAGE_SIZE_BYTES,
+        heartbeat_interval: int | None = None,
+        heartbeat_extension: int = heartbeat.DEFAULT_HEARTBEAT_EXTENSION_SECONDS,
+        heartbeat_max_extensions: int = heartbeat.DEFAULT_HEARTBEAT_MAX_EXTENSIONS,
         tags: dict[str, str] | None = None,
         **options,
     ) -> None:
@@ -104,6 +122,8 @@ class SQSBroker(dramatiq.Broker):
         if max_message_size < 1:
             raise ValueError("'max_message_size' must be a positive number of bytes.")
 
+        heartbeat.validate_config(heartbeat_interval, heartbeat_extension)
+
         self.namespace: str | None = namespace
         self.retention = retention
         self.max_message_size = max_message_size
@@ -112,6 +132,9 @@ class SQSBroker(dramatiq.Broker):
         self.dead_letter_queues: dict[str, Queue] = {}
         self.dead_letter_retention = dead_letter_retention
         self.visibility_timeout = visibility_timeout
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_extension = heartbeat_extension
+        self.heartbeat_max_extensions = heartbeat_max_extensions
         self.tags = tags
         self.sqs: SQSServiceResource = boto3.resource("sqs", **options)
 
@@ -138,6 +161,9 @@ class SQSBroker(dramatiq.Broker):
             timeout,
             dead_letter_queue=dead_letter_queue,
             visibility_timeout=self.visibility_timeout,
+            heartbeat_interval=self.heartbeat_interval,
+            heartbeat_extension=self.heartbeat_extension,
+            heartbeat_max_extensions=self.heartbeat_max_extensions,
         )
 
     def declare_queue(self, queue_name: str) -> None:
@@ -264,6 +290,9 @@ class SQSConsumer(dramatiq.Consumer):
         *,
         dead_letter_queue: "Queue",
         visibility_timeout: int | None = None,
+        heartbeat_interval: int | None = None,
+        heartbeat_extension: int = heartbeat.DEFAULT_HEARTBEAT_EXTENSION_SECONDS,
+        heartbeat_max_extensions: int = heartbeat.DEFAULT_HEARTBEAT_MAX_EXTENSIONS,
     ) -> None:
         self.logger = get_logger(__name__, type(self))
         self.queue = queue
@@ -293,9 +322,18 @@ class SQSConsumer(dramatiq.Consumer):
         self.message_refc = 0
         self.misses = 0
 
+        self.heartbeat = heartbeat.Heartbeat(
+            queue,
+            interval=heartbeat_interval,
+            extension=heartbeat_extension,
+            max_extensions=heartbeat_max_extensions,
+        )
+        self.heartbeat.start()
+
     def ack(self, message: "_SQSMessage") -> None:
         message._sqs_message.delete()
         self.message_refc -= 1
+        self.heartbeat.untrack(message.message_id)
 
     def nack(self, message: "_SQSMessage") -> None:
         if self.dead_letter_queue is not None:
@@ -303,6 +341,7 @@ class SQSConsumer(dramatiq.Consumer):
 
         message._sqs_message.delete()
         self.message_refc -= 1
+        self.heartbeat.untrack(message.message_id)
 
     def requeue(self, messages: Iterable["_SQSMessage"]) -> None:
         for batch in utils.batched(messages, 10):
@@ -321,7 +360,14 @@ class SQSConsumer(dramatiq.Consumer):
             requeued_messages = response.get("Successful", [])
             self.message_refc -= len(requeued_messages)
 
+            for message in batch:
+                self.heartbeat.untrack(message.message_id)
+
     def close(self) -> None:
+        # Stop the heartbeat before draining so it doesn't beat messages we're
+        # about to hand back to SQS.
+        self.heartbeat.stop()
+
         # Drain the prefetch buffer: messages fetched from SQS but never
         # returned via ``__next__`` are invisible until ``VisibilityTimeout``
         # expires. ``Worker.stop`` drains ``work_queue`` and ``delay_queue``
@@ -349,8 +395,12 @@ class SQSConsumer(dramatiq.Consumer):
                     try:
                         encoded_message = b64decode(sqs_message.body)
                         dramatiq_message = dramatiq.Message.decode(encoded_message)
-                        self.messages.append(_SQSMessage(sqs_message, dramatiq_message))
+                        wrapped = _SQSMessage(sqs_message, dramatiq_message)
+                        self.messages.append(wrapped)
                         self.message_refc += 1
+                        # Track from receipt, not process start, so messages
+                        # waiting in the prefetch buffer are heartbeated too.
+                        self.heartbeat.track(wrapped)
                     except Exception:  # pragma: no cover
                         self.logger.exception(
                             "Failed to decode message: %r", sqs_message.body

--- a/src/dramatiq_sqs/heartbeat.py
+++ b/src/dramatiq_sqs/heartbeat.py
@@ -1,0 +1,198 @@
+import dataclasses
+import threading
+from typing import TYPE_CHECKING
+
+from botocore.exceptions import ClientError
+from dramatiq.logging import get_logger
+
+from dramatiq_sqs import utils
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.service_resource import Queue
+
+    from .broker import _SQSMessage
+
+#: Defaults used once the heartbeat is enabled (see ``SQSBroker.heartbeat_interval``).
+DEFAULT_HEARTBEAT_EXTENSION_SECONDS = 120
+DEFAULT_HEARTBEAT_MAX_EXTENSIONS = 60
+
+#: Per-message errors that mean the receipt handle no longer refers to an
+#: in-flight message (already deleted, redelivered or expired). We stop tracking
+#: on these. Any other failure is treated as transient and retried next beat.
+_STALE_RECEIPT_ERROR_CODES = frozenset({"ReceiptHandleIsInvalid", "MessageNotInflight"})
+
+
+@dataclasses.dataclass
+class _Tracked:
+    message: "_SQSMessage"
+    beats: int = 0
+
+
+def validate_config(interval: int | None, extension: int) -> None:
+    if interval is not None and extension <= interval:
+        raise ValueError(
+            f"'heartbeat_extension' ({extension}s) must be greater than "
+            f"'heartbeat_interval' ({interval}s), otherwise the message could "
+            f"expire between beats."
+        )
+
+
+class Heartbeat:
+    """Keeps in-flight SQS messages invisible to other consumers by
+    periodically extending their visibility timeout on a background thread.
+
+    A message is tracked from the moment it's received until it's acked, nacked
+    or requeued, so both long-running tasks and messages sitting in the
+    consumer's prefetch buffer are covered.
+
+    When ``interval`` is ``None`` the heartbeat is disabled: no thread runs and
+    :meth:`track`/:meth:`untrack` are no-ops.
+
+    Each beat extends all tracked messages in one ``ChangeMessageVisibilityBatch``
+    call (in batches of 10), so it costs one request per beat rather than one
+    per message.
+
+    Beats run on one background thread per consumer. Because of the GIL, a
+    worker running CPU-bound work that never releases it can delay beats, so
+    leave enough headroom between ``interval`` and ``extension`` to absorb that
+    (the default 30s/120s leaves 90s of slack). The batch call is I/O and
+    releases the GIL, so the beat thread itself does not block workers.
+
+    Parameters:
+      queue: The SQS queue whose messages this heartbeat extends.
+      interval: How often (in seconds) to extend visibility, or ``None`` to
+        disable.
+      extension: Seconds each beat pushes the visibility deadline forward. Must
+        be greater than ``interval``.
+      max_extensions: Cap on beats per message. After this many beats the
+        message is dropped from tracking and left to SQS to redeliver.
+    """
+
+    def __init__(
+        self,
+        queue: "Queue",
+        *,
+        interval: int | None,
+        extension: int = DEFAULT_HEARTBEAT_EXTENSION_SECONDS,
+        max_extensions: int = DEFAULT_HEARTBEAT_MAX_EXTENSIONS,
+    ) -> None:
+        validate_config(interval, extension)
+
+        self.logger = get_logger(__name__, type(self))
+        self.queue = queue
+        self.interval = interval
+        self.extension = extension
+        self.max_extensions = max_extensions
+        self._tracked: dict[str, _Tracked] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._ticker: threading.Thread | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self.interval is not None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        self._ticker = threading.Thread(
+            target=self._loop,
+            daemon=True,
+            name="sqs-heartbeat",
+        )
+        self._ticker.start()
+
+    def stop(self) -> None:
+        if self._ticker is not None:
+            self._stop.set()
+            self._ticker.join(timeout=(self.interval or 0) + 1)
+        with self._lock:
+            self._tracked.clear()
+
+    def track(self, message: "_SQSMessage") -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._tracked[message.message_id] = _Tracked(message)
+
+    def untrack(self, message_id: str) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._tracked.pop(message_id, None)
+
+    def _loop(self) -> None:
+        # wait() returns True when stop is set and False on timeout, so this
+        # beats every interval and exits promptly on stop().
+        assert self.interval is not None
+        while not self._stop.wait(self.interval):
+            self._beat()
+
+    def _beat(self) -> None:
+        # Snapshot under the lock, then call the API without holding it so
+        # track/untrack aren't blocked on the network.
+        with self._lock:
+            snapshot = list(self._tracked.items())
+
+        to_beat = []
+        for message_id, state in snapshot:
+            if state.beats >= self.max_extensions:
+                self.logger.warning(
+                    "Heartbeat cap hit for message %s after %d extensions, "
+                    "releasing it to SQS.",
+                    message_id,
+                    self.max_extensions,
+                )
+                self.untrack(message_id)
+            else:
+                to_beat.append((message_id, state))
+
+        for batch in utils.batched(to_beat, 10):
+            self._extend(batch)
+
+    def _extend(self, batch: tuple[tuple[str, "_Tracked"], ...]) -> None:
+        entries = [
+            {
+                "Id": str(i),
+                "ReceiptHandle": state.message._sqs_message.receipt_handle,
+                "VisibilityTimeout": self.extension,
+            }
+            for i, (_, state) in enumerate(batch)
+        ]
+        client = self.queue.meta.client
+        try:
+            response = self.queue.change_message_visibility_batch(Entries=entries)
+        except client.exceptions.QueueDoesNotExist:
+            # No queue means no messages to keep alive.
+            self.logger.warning(
+                "Heartbeat queue no longer exists, dropping %d messages from tracking.",
+                len(batch),
+            )
+            for message_id, _ in batch:
+                self.untrack(message_id)
+            return
+        except ClientError as e:
+            # Transient failure (throttling, auth, network). Keep everything
+            # tracked and retry next beat.
+            self.logger.warning(
+                "Heartbeat batch of %d failed (%s), retrying next beat.",
+                len(entries),
+                e.response.get("Error", {}).get("Code", "") or e,
+            )
+            return
+
+        for ok in response.get("Successful", []):
+            _, state = batch[int(ok["Id"])]
+            state.beats += 1
+
+        for fail in response.get("Failed", []):
+            message_id, _ = batch[int(fail["Id"])]
+            if fail.get("Code") in _STALE_RECEIPT_ERROR_CODES:
+                # Message is already gone, nothing to keep alive.
+                self.untrack(message_id)
+            else:
+                self.logger.warning(
+                    "Heartbeat for message %s failed (%s), retrying next beat.",
+                    message_id,
+                    fail.get("Code", ""),
+                )

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,15 +1,58 @@
+import contextlib
 import time
-from collections.abc import Callable
+import uuid
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any
 
 import dramatiq
 import pytest
+from dramatiq.middleware import AgeLimit, Callbacks, Pipelines, Retries, TimeLimit
 
 from dramatiq_sqs import SQSBroker
 from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import SQSServiceResource
+
+
+def _make_broker(
+    elasticmq_endpoint_url: str,
+    namespace: str,
+    tags: dict[str, str],
+    **kwargs: Any,
+) -> SQSBroker:
+    """Build an ad-hoc broker for tests that need custom kwargs.
+
+    Mirrors the conftest ``broker`` fixture but lets each test override knobs
+    like ``visibility_timeout`` or the heartbeat settings.
+    """
+    return SQSBroker(
+        namespace=namespace,
+        middleware=[
+            AgeLimit(),
+            TimeLimit(),
+            Callbacks(),
+            Pipelines(),
+            Retries(min_backoff=1000, max_backoff=900000, max_retries=96),
+        ],
+        tags=tags,
+        region_name="eu-central-1",
+        endpoint_url=elasticmq_endpoint_url,
+        aws_access_key_id="000000000000",
+        aws_secret_access_key="000000000000",
+        **kwargs,
+    )
+
+
+@contextlib.contextmanager
+def _broker_session(broker: SQSBroker) -> Iterator[SQSBroker]:
+    """Set as the global broker, yield, then clean up the queues on exit."""
+    dramatiq.set_broker(broker)
+    try:
+        yield broker
+    finally:
+        for queue in broker.queues.values():
+            queue.delete()
 
 
 def test_can_enqueue_and_process_messages(broker, worker, queue_name):
@@ -282,3 +325,154 @@ def test_declare_queue(
         )
 
         assert sqs.meta.client.list_queue_tags(QueueUrl=sqs_queue.url)["Tags"] == tags
+
+
+# --- Heartbeat ---
+
+
+def test_heartbeat_extension_must_exceed_interval():
+    # When extension <= interval, a message could expire between beats.
+    with pytest.raises(ValueError, match="heartbeat_extension"):
+        SQSBroker(heartbeat_interval=60, heartbeat_extension=60)
+    with pytest.raises(ValueError, match="heartbeat_extension"):
+        SQSBroker(heartbeat_interval=60, heartbeat_extension=30)
+
+
+def test_heartbeat_disabled_by_default(broker, queue_name):
+    # Given the default broker (no heartbeat configured)
+    @dramatiq.actor(queue_name=queue_name)
+    def do_work(x):
+        pass
+
+    do_work.send(1)
+
+    consumer = broker.consume(queue_name)
+    try:
+        msg = next(consumer)
+        assert msg is not None
+        # No ticker thread and nothing tracked.
+        assert consumer.heartbeat.enabled is False
+        assert consumer.heartbeat._ticker is None  # type: ignore[attr-defined]
+        assert consumer.heartbeat._tracked == {}  # type: ignore[attr-defined]
+    finally:
+        consumer.ack(msg)
+        consumer.close()
+
+
+def test_heartbeat_tracks_from_receive_until_ack(
+    elasticmq_endpoint_url, namespace, tags
+):
+    # Given a broker with the heartbeat enabled
+    with _broker_session(
+        _make_broker(
+            elasticmq_endpoint_url,
+            namespace,
+            tags,
+            heartbeat_interval=1,
+            heartbeat_extension=30,
+        )
+    ) as broker:
+        queue_name = f"queue_{uuid.uuid4()}"
+
+        @dramatiq.actor(queue_name=queue_name)
+        def do_work(x):
+            pass
+
+        do_work.send(1)
+        do_work.send(2)
+        # Give SQS a moment so both messages are available in one receive.
+        time.sleep(0.5)
+
+        consumer = broker.consume(queue_name, prefetch=2)
+        try:
+            msg1 = next(consumer)
+            msg2 = next(consumer)
+            assert msg1 is not None
+            assert msg2 is not None
+
+            tracked = consumer.heartbeat._tracked  # type: ignore[attr-defined]
+
+            # Both are tracked from the moment they're received.
+            assert msg1.message_id in tracked
+            assert msg2.message_id in tracked
+
+            # Acking one untracks only that message.
+            consumer.ack(msg1)
+            assert msg1.message_id not in tracked
+            assert msg2.message_id in tracked
+
+            consumer.ack(msg2)
+            assert msg2.message_id not in tracked
+        finally:
+            consumer.close()
+
+
+def test_heartbeat_extends_visibility_for_long_running_task(
+    elasticmq_endpoint_url, namespace, tags
+):
+    # Given a visibility window shorter than the task's runtime, but with the
+    # heartbeat keeping the message in flight.
+    with _broker_session(
+        _make_broker(
+            elasticmq_endpoint_url,
+            namespace,
+            tags,
+            visibility_timeout=3,
+            heartbeat_interval=1,
+            heartbeat_extension=3,
+        )
+    ) as broker:
+        queue_name = f"queue_{uuid.uuid4()}"
+
+        db: list[int] = []
+
+        @dramatiq.actor(queue_name=queue_name, max_retries=0)
+        def slow_work(x: int) -> None:
+            db.append(x)
+            time.sleep(6)  # twice the visibility window
+
+        worker = dramatiq.Worker(broker)
+        worker.start()
+        try:
+            slow_work.send(1)
+            broker.join(queue_name, timeout=15000)
+
+            # Processed exactly once. The heartbeat kept it invisible for the
+            # whole 6s sleep.
+            assert db == [1]
+        finally:
+            worker.stop()
+
+
+def test_without_heartbeat_long_running_task_is_redelivered(
+    elasticmq_endpoint_url, namespace, tags
+):
+    # Control for the test above: with the heartbeat off and a short visibility
+    # window, SQS redelivers the message mid-flight and it runs more than once.
+    with _broker_session(
+        _make_broker(
+            elasticmq_endpoint_url,
+            namespace,
+            tags,
+            visibility_timeout=3,
+            heartbeat_interval=None,
+        )
+    ) as broker:
+        queue_name = f"queue_{uuid.uuid4()}"
+
+        db: list[int] = []
+
+        @dramatiq.actor(queue_name=queue_name, max_retries=0)
+        def slow_work(x: int) -> None:
+            db.append(x)
+            time.sleep(6)
+
+        worker = dramatiq.Worker(broker)
+        worker.start()
+        try:
+            slow_work.send(1)
+            # Long enough for the original run plus at least one redelivery.
+            time.sleep(12)
+            assert len(db) >= 2
+        finally:
+            worker.stop()


### PR DESCRIPTION
An iteration on #53. Same idea, but it moves the complexity out of the broker into a self-contained `Heartbeat` class, and it is opt-in rather than on by default.

## What it does

When enabled, the consumer extends the SQS visibility timeout of in-flight messages on a background thread, which fixes two issues:

1. A long-running task whose runtime exceeds the queue's `VisibilityTimeout` would otherwise be redelivered to another worker while still being processed (duplicate execution).
2. With `prefetch > 1`, prefetched messages sit in the consumer's local buffer and can expire while waiting for a worker to pick them up, even when per-task time looks comfortably under the visibility window.

If a worker dies, beats stop and SQS releases the message within `heartbeat_extension` seconds, so you can run a short visibility window and still avoid mid-flight redelivery.

## Design

- **Opt-in.** Disabled by default (`heartbeat_interval=None`), so there is no behaviour change on upgrade. Enabling it needs the `sqs:ChangeMessageVisibility` IAM permission, which is already required for `requeue`.
- **Self-contained.** The thread, tracking, and beat logic live in a new `Heartbeat` class in `heartbeat.py`. The broker only wires config and delegates, so `broker.py` stays small.
- **Covers the prefetch buffer too.** Messages are tracked from the moment they are received until ack/nack/requeue, not just while processing, so the buffer case is handled without a core `after_message_received` hook. When such a hook lands upstream, this lifts cleanly into a middleware.
- **Batched.** Each beat extends all tracked messages in one `ChangeMessageVisibilityBatch` call, mirroring `requeue`.
- **Error handling.** A stale receipt handle (`ReceiptHandleIsInvalid` / `MessageNotInflight`) or a `QueueDoesNotExist` drops the message from tracking. Anything else is treated as transient and retried on the next beat. A per-message extension cap guards against a stuck worker pinning a message forever.

## Config

- `heartbeat_interval` (default `None`, disabled)
- `heartbeat_extension` (default 120s, must exceed the interval)
- `heartbeat_max_extensions` (default 60)

## Tests

Added tests against the existing ElasticMQ fixture: config validation, disabled-by-default, the receive-to-ack tracking lifecycle, a long-running task surviving a short visibility window, and a control showing redelivery when the heartbeat is off. README and IAM policy updated.