### PR TITLE
refactor: `QueueSet` and `QueueSetRegstry`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ classifiers = [
 ]
 version = "0.4.4"
 requires-python = ">=3.10"
-dependencies = ["boto3", "dramatiq"]
+dependencies = [
+  "boto3",
+  "dramatiq",
+  "typing-extensions >= 4.15.0 ; python_full_version < '3.11'",
+]
 
 [project.urls]
 Repository = "https://github.com/Bogdanp/dramatiq_sqs"

--- a/src/dramatiq_sqs/broker.py
+++ b/src/dramatiq_sqs/broker.py
@@ -12,6 +12,7 @@ from dramatiq.logging import get_logger
 
 from dramatiq_sqs import utils
 from dramatiq_sqs.exceptions import MessageDelayTooLong, MessageTooLarge
+from dramatiq_sqs.queues import QueueSet, QueueSetRegistry
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSClient
@@ -89,8 +90,9 @@ class SQSBroker(dramatiq.Broker):
         tags: dict[str, str] | None = None,
         **options,
     ) -> None:
-        self.queue_names: set[str] = set()
-
+        self.queuesets: QueueSetRegistry[str] = QueueSetRegistry(
+            factory=self._ensure_queue
+        )
         super().__init__(middleware=middleware)
 
         if (
@@ -108,14 +110,11 @@ class SQSBroker(dramatiq.Broker):
         self.namespace: str | None = namespace
         self.retention = retention
         self.max_message_size = max_message_size
-        #: Maps Dramatiq queue names to their SQS queue URLs.
-        self.queues: dict[str, str] = {}
         self.dead_letter = dead_letter
-        #: Maps Dramatiq queue names to their SQS dead-letter queue URLs.
-        self.dead_letter_queues: dict[str, str] = {}
         self.dead_letter_retention = dead_letter_retention
         self.visibility_timeout = visibility_timeout
         self.tags = tags
+
         # A broker is shared by every worker thread (and, for ``enqueue``, by
         # arbitrary application threads such as a web server's).  boto3 resources
         # are not thread-safe and must not be shared across threads, but clients
@@ -133,48 +132,41 @@ class SQSBroker(dramatiq.Broker):
         prefetch: int = 1,
         timeout: int = MAX_WAIT_TIME_SECONDS * 1000,
     ) -> dramatiq.Consumer:
-        self._ensure_queue(queue_name)
-
-        dead_letter_queue_url = (
-            self.dead_letter_queues[queue_name] if self.dead_letter else None
-        )
-
         return self.consumer_class(
             self.client,
-            self.queues[queue_name],
+            self.queuesets[queue_name].queue,
             prefetch,
             timeout,
-            dead_letter_queue_url=dead_letter_queue_url,
+            dead_letter_queue_url=self.queuesets[queue_name].dl_queue,
             visibility_timeout=self.visibility_timeout,
         )
 
     def declare_queue(self, queue_name: str) -> None:
-        if queue_name not in self.queue_names:
+        if queue_name not in self.queuesets:
             self.emit_before("declare_queue", queue_name)
-            self.queue_names.add(queue_name)
+            self.queuesets.declare_queueset(queue_name)
             self.emit_after("declare_queue", queue_name)
 
-    def _ensure_queue(self, queue_name: str) -> None:
-        if queue_name not in self.queue_names:
-            raise dramatiq.QueueNotFound(queue_name)
-
+    def _ensure_queue(self, queue_name: str) -> QueueSet[str]:
         sqs_queue_name = (
             f"{self.namespace}_{queue_name}" if self.namespace else queue_name
         )
 
-        if queue_name not in self.queues:
-            self.queues[queue_name] = self._get_or_create_sqs_queue(
-                sqs_queue_name, message_retention_period=self.retention, tags=self.tags
-            )
+        sqs_queue = self._get_or_create_sqs_queue(
+            sqs_queue_name, message_retention_period=self.retention, tags=self.tags
+        )
 
-        sqs_dead_letter_queue_name = f"{sqs_queue_name}_dlq"
-
-        if self.dead_letter and queue_name not in self.dead_letter_queues:
-            self.dead_letter_queues[queue_name] = self._get_or_create_sqs_queue(
-                sqs_dead_letter_queue_name,
+        if self.dead_letter:
+            sqs_dl_queue_name = f"{sqs_queue_name}_dlq"
+            sqs_dl_queue = self._get_or_create_sqs_queue(
+                sqs_dl_queue_name,
                 message_retention_period=self.dead_letter_retention,
                 tags=self.tags,
             )
+        else:
+            sqs_dl_queue = None
+
+        return QueueSet(queue_name, sqs_queue, sqs_dl_queue)
 
     def _get_or_create_sqs_queue(
         self,
@@ -206,9 +198,8 @@ class SQSBroker(dramatiq.Broker):
         self, message: dramatiq.Message, *, delay: int | None = None
     ) -> dramatiq.Message:
         queue_name = message.queue_name
-        self._ensure_queue(queue_name)
 
-        queue_url = self.queues[queue_name]
+        queue_url = self.queuesets[queue_name].queue
         delay_seconds = (delay or 0) // 1000
 
         if delay_seconds > MAX_DELAY_SECONDS:
@@ -235,7 +226,7 @@ class SQSBroker(dramatiq.Broker):
         return message
 
     def join(self, queue_name: str, *, timeout: int | None = None) -> None:
-        queue_url = self.queues[queue_name]
+        queue_url = self.queuesets[queue_name].queue
 
         deadline = timeout and time.monotonic() + timeout
 
@@ -265,7 +256,7 @@ class SQSBroker(dramatiq.Broker):
             time.sleep(1)
 
     def get_declared_queues(self) -> Iterable[str]:
-        return set(self.queue_names)
+        return self.queuesets.declared_queuesets
 
     def get_declared_delay_queues(self) -> Iterable[str]:
         return set()

--- a/src/dramatiq_sqs/queues.py
+++ b/src/dramatiq_sqs/queues.py
@@ -1,0 +1,44 @@
+import sys
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+import dramatiq
+
+if sys.version_info >= (3, 11):
+    from typing import NamedTuple
+else:
+    from typing_extensions import NamedTuple
+
+
+_Q = TypeVar("_Q")
+
+
+class QueueSet(NamedTuple, Generic[_Q]):
+    name: str
+    queue: _Q
+    dl_queue: _Q | None
+
+
+class QueueSetRegistry(dict[str, QueueSet[_Q]]):
+    def __init__(
+        self,
+        queuesets: dict[str, QueueSet[_Q]] | None = None,
+        factory: Callable[[str], QueueSet[_Q]] | None = None,
+    ) -> None:
+        super().__init__(queuesets or ())
+        self._names = set(self.keys())
+        self._factory = factory
+
+    def declare_queueset(self, name: str) -> None:
+        self._names.add(name)
+
+    @property
+    def declared_queuesets(self) -> set[str]:
+        return self._names
+
+    def __missing__(self, name: str) -> QueueSet[_Q]:
+        if name in self._names and self._factory is not None:
+            queueset = self[name] = self._factory(name)
+            return queueset
+
+        raise dramatiq.QueueNotFound(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,11 +64,11 @@ def broker(
 
     yield broker
 
-    for queue_url in broker.queues.values():
-        broker.client.delete_queue(QueueUrl=queue_url)
+    for queueset in broker.queuesets.values():
+        broker.client.delete_queue(QueueUrl=queueset.queue)
 
-    for queue_url in broker.dead_letter_queues.values():
-        broker.client.delete_queue(QueueUrl=queue_url)
+        if queueset.dl_queue is not None:
+            broker.client.delete_queue(QueueUrl=queueset.dl_queue)
 
 
 @pytest.fixture

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -54,9 +54,9 @@ def test_failed_messages_are_sent_to_dlq(
 
     broker.join(queue_name)
 
-    dlq_url = broker.dead_letter_queues[queue_name]
+    dl_queue_url = broker.queuesets[queue_name].dl_queue
     messages = broker.client.receive_message(
-        QueueUrl=dlq_url, MaxNumberOfMessages=10
+        QueueUrl=dl_queue_url, MaxNumberOfMessages=10
     ).get("Messages", [])
     assert len(messages) == attempts
 

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "dramatiq" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -266,6 +267,7 @@ dev = [
 requires-dist = [
     { name = "boto3" },
     { name = "dramatiq" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
`QueueSet` simply tracks a queue together with its (optionally) associated dead letter queue.
`QueueSetRegistry` is basically a `defaultdict` with a couple twists for lazy initialization of queues.
Together these should provide a QoL increase over working with separate `queues` + `dead_letter_queues`.

Both abstractions are generic and SQS-agnostic, as they theoretically can also be useful in other brokers / core dramatiq. Upstreaming is not yet in the plans though.